### PR TITLE
#1503 Improve test testStopListeningForConnectionsReleasesPort in TCP…

### DIFF
--- a/ThaliCoreTests/SocketConnectionTests/TCPListenerTests.swift
+++ b/ThaliCoreTests/SocketConnectionTests/TCPListenerTests.swift
@@ -332,21 +332,38 @@ class TCPListenerTests: XCTestCase {
                                         socketDisconnected: unexpectedSocketDisconnectHandler,
                                         stoppedListening: unexpectedStopListeningHandler)
 
-    // When
-    secondTcpListener.startListeningForConnections(
-                                          on: potentiallyReleasedPort,
-                                          connectionAccepted: unexpectedAcceptConnectionHandler) {
-        port, error in
-        XCTAssertNil(error)
-        XCTAssertNotNil(port)
-        TCPListenerIsListening?.fulfill()
-    }
+    var listenCallsCount = 1
+    let maxListenCallsCount = 5
 
-    // Then
-    waitForExpectations(timeout: startListeningTimeout) {
-      error in
-      TCPListenerIsListening = nil
+    var listenClosedPort = {}
+    listenClosedPort = {
+      secondTcpListener.startListeningForConnections(on: potentiallyReleasedPort,
+                                                     connectionAccepted: unexpectedAcceptConnectionHandler) {
+          port, error in
+
+          guard let _ = port, error == nil else {
+            if listenCallsCount < maxListenCallsCount {
+              listenCallsCount += 1
+              
+              listenClosedPort()
+            } else {
+              XCTAssertNil(error)
+              XCTAssertNotNil(port)
+            }
+            
+            return
+          }
+          
+          TCPListenerIsListening?.fulfill()
+      }
+      
+      self.waitForExpectations(timeout: self.startListeningTimeout) {
+        error in
+        TCPListenerIsListening = nil
+      }
     }
+    
+    listenClosedPort()
   }
 
   func testStopListeningForConnectionsDisconnectsClient() {

--- a/ThaliCoreTests/SocketConnectionTests/TCPListenerTests.swift
+++ b/ThaliCoreTests/SocketConnectionTests/TCPListenerTests.swift
@@ -340,17 +340,14 @@ class TCPListenerTests: XCTestCase {
       secondTcpListener.startListeningForConnections(on: potentiallyReleasedPort,
                                                      connectionAccepted: unexpectedAcceptConnectionHandler) {
           port, error in
-
           guard let _ = port, error == nil else {
             if listenCallsCount < maxListenCallsCount {
               listenCallsCount += 1
-              
               listenClosedPort()
             } else {
               XCTAssertNil(error)
               XCTAssertNotNil(port)
             }
-            
             return
           }
           


### PR DESCRIPTION
Call listen in testStopListeningForConnectionsReleasesPort multiple times after socket has been closed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali-ios/4)
<!-- Reviewable:end -->
