### PR TITLE
Prevent possible crash if 'nonTCPsession' is null

### DIFF
--- a/ThaliCore/SocketConnection/BrowserRelay.swift
+++ b/ThaliCore/SocketConnection/BrowserRelay.swift
@@ -212,7 +212,7 @@ final class BrowserRelay {
       return
     }
 
-    self.nonTCPsession.disconnect()
+    disconnectNonTCPSession()
   }
 
   // This is called after both the input and output have been opened
@@ -229,6 +229,11 @@ final class BrowserRelay {
   fileprivate func createVirtualSocket(
                       with completion: @escaping ((VirtualSocket?, Error?) -> Void)) {
     print("[ThaliCore] BrowserRelay.\(#function)")
+
+    guard self.nonTCPsession != nil else {
+      completion(nil, ThaliCoreError.sessionDisconnected)
+      return
+    }
 
     let newStreamName = UUID().uuidString
     let virtualSocketBuilder = BrowserVirtualSocketBuilder(

--- a/ThaliCore/SocketConnection/VirtualSocketBuilder.swift
+++ b/ThaliCore/SocketConnection/VirtualSocketBuilder.swift
@@ -17,7 +17,7 @@ class VirtualSocketBuilder {
   /**
    Represents non-TCP/IP session.
    */
-  fileprivate let nonTCPsession: Session
+  fileprivate let nonTCPsession: Session?
 
   /**
    Represents object that provides write-only stream functionality.
@@ -119,7 +119,7 @@ final class BrowserVirtualSocketBuilder: VirtualSocketBuilder {
   func startBuilding(with completion: @escaping (VirtualSocket?, Error?) -> Void) {
     self.completion = completion
 
-    let outputStream = nonTCPsession.startOutputStream(with: streamName)
+    let outputStream = nonTCPsession?.startOutputStream(with: streamName)
     guard outputStream != nil else {
       print("[ThaliCore] VirtualSocketBuilder: startOutputStream() failed)")
       self.completion?(nil, ThaliCoreError.connectionFailed)


### PR DESCRIPTION
The fix has already been tested. Not having the time to do the usual formal review process, I will merge it directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali-ios/13)
<!-- Reviewable:end -->
